### PR TITLE
Actually use str, len in flb_ra_strcmp

### DIFF
--- a/src/flb_record_accessor.c
+++ b/src/flb_record_accessor.c
@@ -691,7 +691,7 @@ int flb_ra_strcmp(struct flb_record_accessor *ra, msgpack_object map,
 
     rp = mk_list_entry_first(&ra->list, struct flb_ra_parser, _head);
     return flb_ra_key_strcmp(rp->key->name, map, rp->key->subkeys,
-                             rp->key->name, flb_sds_len(rp->key->name));
+                             str, len);
 }
 
 /*


### PR DESCRIPTION
Arguments `str` and `len` are not used in `flb_ra_strmp`. Instead, it passes `rp->key->name` to `flb_ra_key_strcmp` twice which means that it compares the key name with its corresponding value, which I believe is not the expected behavior.

Testing is not applicable because no other code uses this function, but I use it in my plugin.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
